### PR TITLE
Fixed reference to `esphome-component-dynamic-on-time` component

### DIFF
--- a/schedule.yaml
+++ b/schedule.yaml
@@ -179,7 +179,7 @@ number:
     mode: box
 
 external_components:
-  source: github://hostcc/esphome-component-dynamic-on-time@1.1.0
+  - source: github://hostcc/esphome-component-dynamic-on-time@1.1.0
 
 dynamic_on_time:
   - id: lawn_schedule


### PR DESCRIPTION
* `schedule.yaml`: Fixed reference to `esphome-component-dynamic-on-time` external component to allow consuming code to use other external entities if needed