### PR TITLE
Update ESPHome version

### DIFF
--- a/display.yaml
+++ b/display.yaml
@@ -13,7 +13,7 @@ esphome:
 spi:
   clk_pin: GPIO2
   mosi_pin: GPIO3
-  force_sw: false
+  interface: hardware
 
 switch:
   - platform: gpio

--- a/main.yaml
+++ b/main.yaml
@@ -36,6 +36,6 @@ packages:
   time: !include time.yaml  # Optional
   rtc: !include rtc.yaml  # Optional
 
-# 2023.10.0 addresses Pillow security vulnerability
+# 2024.2.0 addresses Pillow security vulnerability
 esphome:
-  min_version: '2023.10.0'
+  min_version: '2024.2.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome>=2023.10.0
-pillow==10.0.1
+esphome==2024.2.0
+pillow==10.2.0

--- a/tests/rp2040w.yaml
+++ b/tests/rp2040w.yaml
@@ -3,6 +3,9 @@
 
 # Minimal configuration to validate via ESPHome
 ---
+logger:
+  level: debug
+
 esphome:
   name: test-2040w
 


### PR DESCRIPTION
* Required ESPHome version has been updated to 2024.2.0 to address another Pillow vulnerability fixed in 10.2.0