### PR TITLE
Externalize platform sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Optionally:
 ### Pico-Relay-B hardware modifications
 
 The stock Pico-Relay-B lacks GPIO exposed via a terminal - those are needed to
-connect rain sensor and water tank empty one, the crew terminal (4 pins) has
+connect rain sensor and water tank empty one, the screw terminal (4 pins) has
 been added (lower left corner).
 
 Also, the hardware initially had no RTC, DS3231 has been added (top left
@@ -124,7 +124,23 @@ version (see
 [Releases](https://github.com/hostcc/esphome-config-sprinkler/releases)) to
 ensure your configuration is stable over the time.
 
+A temperature sensor is a prerequisite to the configuration, its ID should be
+passed via `temperature_sensor_id` substitution - it is only used by display
+component currently.
+
+
 ```yaml
+substitutions:
+  temperature_sensor_id: temperature_sensor
+
+sensor:
+  - platform: internal_temperature
+    id: ${temperature_sensor_id}
+    name: "Internal Temperature"
+    icon: "mdi:thermometer"
+    entity_category: diagnostic
+    update_interval: 60s
+
 packages:
   sprinkler: github://hostcc/esphome-config-sprinkler/main.yaml@<release version>
 ```

--- a/display.yaml
+++ b/display.yaml
@@ -188,5 +188,5 @@ display:
           it.print( 0, 36, material, TextAlign::CENTER_LEFT, "\U0000e1ff");
           it.printf(
             84, 36, primary, TextAlign::CENTER_RIGHT, "%.1f C",
-            id(temperature).state
+            id(${temperature_sensor_id}).state
           );

--- a/main.yaml
+++ b/main.yaml
@@ -24,6 +24,7 @@ substitutions:
   display_rotation: '0'
   rtc_id: rtc_time
   timezone: UTC
+  temperature_sensor_id: temperature
 
 packages:
   outputs: !include outputs.yaml

--- a/status_sensors.yaml
+++ b/status_sensors.yaml
@@ -1,14 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2023 Ilia Sotnikov
 ---
-sensor:
-  - platform: internal_temperature
-    id: temperature
-    name: "Internal Temperature"
-    icon: "mdi:thermometer"
-    entity_category: diagnostic
-    update_interval: 60s
-
 text_sensor:
   - platform: template
     id: lawn_sprinklers_state

--- a/tests/rp2040w.yaml
+++ b/tests/rp2040w.yaml
@@ -3,6 +3,9 @@
 
 # Minimal configuration to validate via ESPHome
 ---
+substitutions:
+  temperature_sensor_id: temperature_sensor
+
 logger:
   level: debug
 
@@ -17,6 +20,14 @@ rp2040:
 api:
 wifi:
   ap:
+
+sensor:
+  - platform: internal_temperature
+    id: ${temperature_sensor_id}
+    name: "Internal Temperature"
+    icon: "mdi:thermometer"
+    entity_category: diagnostic
+    update_interval: 60s
 
 packages:
   main: !include


### PR DESCRIPTION
* Externalized temperature sensor, which is to be provided outside of  the configuration (ID is supplied via `temperature_sensor_id` substitution)