### PR TITLE
chore: Update minimal ESPHome version to `2024.11.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # You can modify this file to suit your needs.
 /.esphome/
 /secrets.yaml
+/.venv/

--- a/main.yaml
+++ b/main.yaml
@@ -37,6 +37,6 @@ packages:
   time: !include time.yaml  # Optional
   rtc: !include rtc.yaml  # Optional
 
-# 2024.3.0 addresses security vulnerability
+# 2024.11.0 addresses security vulnerability
 esphome:
-  min_version: '2024.3.0'
+  min_version: '2024.11.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2024.9.1
-pillow==10.2.0
+esphome==2024.11.2
+pillow==10.4.0


### PR DESCRIPTION
* `2024.11.0` of ESPHome fixes security vulnerability with Pillow
* Most recent ESPHome version is used for tests