### PR TITLE
fix: C++ includes with newer ESPHome versions

### DIFF
--- a/display.yaml
+++ b/display.yaml
@@ -169,7 +169,6 @@ display:
       - id: display_page2
         lambda: |-
           #include <esphome/components/wifi/wifi_component.h>
-          
           using namespace esphome::wifi;
 
           // Symbol indicating whether WiFi is connected and its signal level

--- a/display.yaml
+++ b/display.yaml
@@ -91,7 +91,7 @@ display:
     pages:
       - id: display_page1
         lambda: |-
-          #include "esphome/components/api/api_server.h"
+          #include <esphome/components/api/api_server.h>
           using namespace esphome::api;
 
           // Day of week and time
@@ -168,7 +168,8 @@ display:
 
       - id: display_page2
         lambda: |-
-          #include "esphome/components/wifi/wifi_component.h"
+          #include <esphome/components/wifi/wifi_component.h>
+          
           using namespace esphome::wifi;
 
           // Symbol indicating whether WiFi is connected and its signal level

--- a/indicators.yaml
+++ b/indicators.yaml
@@ -35,7 +35,7 @@ light:
           update_interval: 2s
     on_turn_on:
       - lambda: |-
-          #include "esphome/components/sprinkler/sprinkler.h"
+          #include <esphome/components/sprinkler/sprinkler.h>
           if (
             id(lawn_sprinklers).controller_state()
               != esphome::sprinkler::SprinklerState::IDLE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2024.11.2
+esphome==2025.7.4
 pillow==10.4.0

--- a/script_refill_tank.yaml
+++ b/script_refill_tank.yaml
@@ -4,7 +4,7 @@
 if:
   condition:
     lambda: |-
-      #include "esphome/core/component.h"
+      #include <esphome/core/component.h>
       return
         (${condition})
         // Ignore the fragment being triggered during 'sprinkler' component


### PR DESCRIPTION
* Resolves error below with newer ESPHome introduced Jinja support

        Error while parsing config: TypeError Error evaluating jinja expression '#include "..."'