### PR TITLE
fix: Update `dynamic_on_time` component and dependencies

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - run: pip install yamllint
       - run: yamllint .
 
@@ -27,6 +27,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - run: pip install -r requirements.txt
       - run: esphome compile tests/rp2040w.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2025.7.4
+esphome==2025.8.0
 pillow==10.4.0

--- a/schedule.yaml
+++ b/schedule.yaml
@@ -189,7 +189,7 @@ number:
     mode: box
 
 external_components:
-  - source: github://hostcc/esphome-component-dynamic-on-time@1.1.0
+  - source: github://hostcc/esphome-component-dynamic-on-time@1.1.1
 
 dynamic_on_time:
   - id: lawn_schedule

--- a/tests/rp2040w.yaml
+++ b/tests/rp2040w.yaml
@@ -15,10 +15,6 @@ esphome:
 rp2040:
   board: rpipicow
   framework:
-    # Pinned to specific version to prevent compilation failure,
-    # see https://github.com/esphome/esphome/pull/7514
-    platform_version: >-
-      https://github.com/maxgerhardt/platform-raspberrypi.git#v1.2.0-gcc12
 
 api:
 wifi:

--- a/tests/rp2040w.yaml
+++ b/tests/rp2040w.yaml
@@ -14,7 +14,6 @@ esphome:
 
 rp2040:
   board: rpipicow
-  framework:
 
 api:
 wifi:


### PR DESCRIPTION
* `dynamic_on_time` component updated to version [1.1.1](https://github.com/hostcc/esphome-component-dynamic-on-time/releases/tag/1.1.1) to address its issue with ESPHome 2025.8.0
* `requirements.txt`: Updated ESPHome to most recent version (2025.8.0)
* `tests/rp2040w.yaml``: Removed pinning framework version as no longe needed
* Github actions: ESPHome requires Python 3.11+, hence jobs have been switched to 3.13