### PR TITLE
fix: Update `dynamic-on-time` component version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2025.8.0
+esphome==2025.8.3
 pillow==10.4.0

--- a/schedule.yaml
+++ b/schedule.yaml
@@ -189,7 +189,7 @@ number:
     mode: box
 
 external_components:
-  - source: github://hostcc/esphome-component-dynamic-on-time@1.1.1
+  - source: github://hostcc/esphome-component-dynamic-on-time@1.1.2
 
 dynamic_on_time:
   - id: lawn_schedule


### PR DESCRIPTION
* `dynamic_on_time` component has been updated to version `1.1.2` to fix disabling the schedule not working as expected.
* Updated ESPHome to version `2025.8.3` for recent security fix.