### PR TITLE
fix: Disabled schedule not being persisted

### DIFF
--- a/controllers.yaml
+++ b/controllers.yaml
@@ -229,8 +229,8 @@ switch:
           id(flowerbed_sprinklers_standby_switch).turn_on();
           #ifdef HAS_SCHEDULE
           // Disable scheduled runs
-          lawn_sprinklers_disabled->turn_on();
-          flowerbed_sprinklers_disabled->turn_on();
+          lawn_sprinklers_disabled_aggregate->turn_on();
+          flowerbed_sprinklers_disabled_aggregate->turn_on();
           #endif
           // Turn off peripherals power (water level relay and alike)
           id(${peripherals_power_off_relay_id}).turn_on();
@@ -240,9 +240,9 @@ switch:
           id(flowerbed_sprinklers_standby_switch).turn_off();
           id(lawn_sprinklers_standby_switch).turn_off();
           #ifdef HAS_SCHEDULE
-          // Enabled scheduled runs
-          lawn_sprinklers_disabled->turn_off();
-          flowerbed_sprinklers_disabled->turn_off();
+          // Enable scheduled runs
+          lawn_sprinklers_disabled_aggregate->turn_off();
+          flowerbed_sprinklers_disabled_aggregate->turn_off();
           #endif
           // Enable peripherals power
           id(${peripherals_power_off_relay_id}).turn_off();

--- a/schedule.yaml
+++ b/schedule.yaml
@@ -66,11 +66,20 @@ switch:
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
     entity_category: config
+  # Internal switch that aggregates state of winter mode and the user-visible
+  # switch above. The intermediate entity is needed to prevent winter mode from
+  # affecting the state of the schedule might have been set by the user
+  - platform: template
+    id: lawn_sprinklers_disabled_aggregate
+    internal: true
+    optimistic: true
+    restore_mode: DISABLED
     lambda: |-
       // Prevent enabling schedule if winter mode is active
       if (id(winter_mode).state)
         return true;
-      return {};
+      // Otherwise, follow the state of the switch above
+      return id(lawn_sprinklers_disabled).state;
 
   # Schedule, flowerbed sprinklers
   - platform: template
@@ -129,11 +138,17 @@ switch:
     optimistic: true
     restore_mode: RESTORE_DEFAULT_OFF
     entity_category: config
+  # See comment above on its purpose
+  - platform: template
+    id: flowerbed_sprinklers_disabled_aggregate
+    internal: true
+    optimistic: true
+    restore_mode: DISABLED
     lambda: |-
       // See above
       if (id(winter_mode).state)
         return true;
-      return {};
+      return id(flowerbed_sprinklers_disabled).state;
 
 number:
   # Schedule, lawn sprinklers
@@ -203,7 +218,7 @@ dynamic_on_time:
     fri: lawn_sprinklers_fri
     sat: lawn_sprinklers_sat
     sun: lawn_sprinklers_sun
-    disabled: lawn_sprinklers_disabled
+    disabled: lawn_sprinklers_disabled_aggregate
     on_time:
       - logger.log:
           format: 'schedule: Waiting for water tank to be full'
@@ -229,7 +244,7 @@ dynamic_on_time:
     fri: flowerbed_sprinklers_fri
     sat: flowerbed_sprinklers_sat
     sun: flowerbed_sprinklers_sun
-    disabled: flowerbed_sprinklers_disabled
+    disabled: flowerbed_sprinklers_disabled_aggregate
     on_time:
       - logger.log:
           format: 'schedule: Waiting for water tank to be full'


### PR DESCRIPTION
Fixed issue when disabled schedule reverts back to enabled upon reboot. That is due to `winter_mode` switch restores to OFF (apparently, when winter mode is disabled) triggering its `turn_off_action`, which turns off both controls to disable lawn and flowerbed sprinklers. The issue manifests itself only when winter mode is disabled.

  The fix is to introduce the internal switches (for each of user-visible controls disabling each of schedules), those aggregate state of winter mode and the corresponding user-visible switch. The intermediate entity is then controlled by `winter_mode` switch, and prevents that affecting the state of the schedule might have been set by the user.