### PR TITLE
feat: Reset paused valve on stop

### DIFF
--- a/controllers.yaml
+++ b/controllers.yaml
@@ -220,10 +220,16 @@ switch:
     restore_mode: RESTORE_DEFAULT_OFF
     entity_category: config
     turn_on_action:
+      # Shutdown active operations on controllers if any
+      - lambda: !include
+          file: script_reset_controller.yaml
+          vars:
+            sprinkler: lawn_sprinklers
+      - lambda: !include
+          file: script_reset_controller.yaml
+          vars:
+            sprinkler: flowerbed_sprinklers
       - lambda: |-
-          // Shutdown active operations on controllers if any
-          id(lawn_sprinklers).shutdown();
-          id(flowerbed_sprinklers).shutdown();
           // Put controllers into standby
           id(lawn_sprinklers_standby_switch).turn_on();
           id(flowerbed_sprinklers_standby_switch).turn_on();
@@ -263,8 +269,15 @@ button:
   - platform: template
     name: "Lawn sprinklers: shutdown"
     on_press:
-      - sprinkler.shutdown: lawn_sprinklers
+      - lambda: !include
+          file: script_reset_controller.yaml
+          vars:
+            sprinkler: lawn_sprinklers
+
   - platform: template
     name: "Flowerbed sprinklers: shutdown"
     on_press:
-      - sprinkler.shutdown: flowerbed_sprinklers
+      - lambda: !include
+          file: script_reset_controller.yaml
+          vars:
+            sprinkler: flowerbed_sprinklers

--- a/script_reset_controller.yaml
+++ b/script_reset_controller.yaml
@@ -2,5 +2,6 @@
 # Copyright (c) 2025 Ilia Sotnikov
 ---
 !lambda |-
+  // `true` parameter clears any queued values as well
   id(${sprinkler}).shutdown(true);
   id(${sprinkler}).reset_resume();

--- a/script_reset_controller.yaml
+++ b/script_reset_controller.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Ilia Sotnikov
+---
+!lambda |-
+  id(${sprinkler}).shutdown(true);
+  id(${sprinkler}).reset_resume();


### PR DESCRIPTION
* When a controller is stopped (either by pressing corrsponding `Shutdown` button or when enabling the winter mode) any paused and queued valves are reset. An use case is to shutdown a watering cycle with valves paused, when the cycle should not be running (e.g. started by mistake but paused due to tank being empty).