### PR TITLE
fix: Use proper timezone defaults

### DIFF
--- a/substitutions.yaml
+++ b/substitutions.yaml
@@ -21,5 +21,5 @@ substitutions:
   display_id: display1
   display_rotation: '0'
   rtc_id: rtc_time
-  timezone: UTC
+  timezone: Etc/UTC
   temperature_sensor_id: temperature


### PR DESCRIPTION
* `timezone` variable now contains correct default valie, `Etc/UTC` - previous one (`UTC`) isn't valid as per TZ database