### PR TITLE
fix: Proper preprocessor directives and substitutions in lambdas. Display contrast defaults.

### DIFF
--- a/display.yaml
+++ b/display.yaml
@@ -85,7 +85,8 @@ display:
     reset_pin: GPIO7
     cs_pin: GPIO10
     dc_pin: GPIO11
-    contrast: 0xff
+    # ESPHome 2026.4.0 enforces the documented 0..127 range.
+    contrast: 0x7f
     rotation: ${display_rotation}
     # Make display updates every second so information is up to date
     update_interval: 1s

--- a/script_controller_run_time_remaining.yaml
+++ b/script_controller_run_time_remaining.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-1.0
 # Copyright (c) 2023 Ilia Sotnikov
 ---
-!lambda |-
+|-
   auto time_remaining =
     id(${sprinkler}).time_remaining_active_valve().value_or(0);
 

--- a/script_controller_status.yaml
+++ b/script_controller_status.yaml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-1.0
 # Copyright (c) 2023 Ilia Sotnikov
 ---
-!lambda |-
-  #include <esphome/components/sprinkler/sprinkler.h>
-  #define PAUSED_STR "Paused: "
-  #define PAUSED_STR_LEN sizeof(PAUSED_STR) - 1
+|-
+  %:include <esphome/components/sprinkler/sprinkler.h>
+  %:define PAUSED_STR "Paused: "
+  %:define PAUSED_STR_LEN sizeof(PAUSED_STR) - 1
   auto paused_valve = id(${sprinkler}).paused_valve();
   if (paused_valve.has_value()) {
     auto paused_valve_name = id(${sprinkler}).valve_name(paused_valve.value());

--- a/script_rain_water_tank_sensors_action.yaml
+++ b/script_rain_water_tank_sensors_action.yaml
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-1.0
 # Copyright (c) 2023 Ilia Sotnikov
 ---
-!lambda |-
+|-
   // Define preprocessor macro after entity triggered the script for
   // conditionals
-  #include "esphome/core/log.h"
-  #define TRIGGERED_BY_${triggered_by}
+  // ESPHome 2026.4.0 evaluates this file as Jinja and treats leading '#...'
+  // preprocessor lines as template tags. Use C/C++ digraph '%:' for '#'.
+  %:include "esphome/core/log.h"
+  %:define TRIGGERED_BY_${triggered_by}
 
   // No further manipulations if winter mode is enabled
   if (id(winter_mode).state) {
@@ -15,59 +17,59 @@
     return;
   }
 
-  #ifdef HAS_CUSTOM_INPUTS
+  %:ifdef HAS_CUSTOM_INPUTS
   // Handle rain detected or water tank is empty
   if (${rain_sensor_id}->state || ${water_tank_empty_id}->state) {
     ESP_LOGI(
       "${triggered_by}",
       "%s sprinklers and putting them in standby"
       " (rain sensor state: %s, water tank empty state: %s)",
-      #ifdef TRIGGERED_BY_${rain_sensor_id}
+      %:ifdef TRIGGERED_BY_${rain_sensor_id}
       "Stopping"
-      #else
+      %:else
       "Pausing"
-      #endif
+      %:endif
       , ONOFF(${rain_sensor_id}->state)
       , ONOFF(${water_tank_empty_id}->state)
     );
 
     // Explicitly shutdown any running operation in case of rain, also turn on
     // LED indicating the condition
-    #ifdef TRIGGERED_BY_${rain_sensor_id}
-    #ifdef HAS_RGB_LED
+    %:ifdef TRIGGERED_BY_${rain_sensor_id}
+    %:ifdef HAS_RGB_LED
     auto call = ${led_id}->turn_on();
     call.perform();
-    #endif
+    %:endif
     id(flowerbed_sprinklers).shutdown();
     id(lawn_sprinklers).shutdown();
-    #endif
+    %:endif
 
     // Pause any active operation if water tank is empty, so it could resume
     // once it becomes full
     // NOTE: `pause()` should be called before activating controller's standby
     // switch, since it internally calls `shutdown` thus active valve will be
     // lost
-    #ifdef TRIGGERED_BY_${water_tank_empty_id}
+    %:ifdef TRIGGERED_BY_${water_tank_empty_id}
     id(flowerbed_sprinklers).pause();
     id(lawn_sprinklers).pause();
-    #endif
+    %:endif
 
     // Put sprinklers into standby mode
     id(flowerbed_sprinklers_standby_switch).turn_on();
     id(lawn_sprinklers_standby_switch).turn_on();
 
-    #ifdef HAS_DISPLAY
+    %:ifdef HAS_DISPLAY
     if (${display_id}->is_ready()) {
       ${display_id}->update();
     }
-    #endif
+    %:endif
 
     // Any active condition above is terminating, i.e. if one sensor is active
     // stopping/pausing won't be reverted by processing another sensor being
     // inactive
     return;
   }
-  #endif  // HAS_CUSTOM_INPUTS
+  %:endif  // HAS_CUSTOM_INPUTS
 
   ESP_LOGI(
     "${triggered_by}", "Putting sprinklers out of standby"
@@ -77,29 +79,29 @@
   id(lawn_sprinklers_standby_switch).turn_off();
 
   // Turn off LED indicating that rain is detected
-  #ifdef TRIGGERED_BY_${rain_sensor_id}
-  #ifdef HAS_RGB_LED
+  %:ifdef TRIGGERED_BY_${rain_sensor_id}
+  %:ifdef HAS_RGB_LED
   auto call = ${led_id}->turn_off();
   call.perform();
-  #endif
-  #endif
+  %:endif
+  %:endif
 
   // Resume any operation if any once water tank is full
   // NOTE: should be called after moving controller out of standby otherwise
   // `resume()` will do nothing
-  #ifdef TRIGGERED_BY_${water_tank_empty_id}
+  %:ifdef TRIGGERED_BY_${water_tank_empty_id}
   ESP_LOGI("${triggered_by}", "Resuming sprinklers");
   id(flowerbed_sprinklers).resume();
   id(lawn_sprinklers).resume();
-  #endif
+  %:endif
 
-  #ifdef HAS_DISPLAY
+  %:ifdef HAS_DISPLAY
   if (${display_id}->is_ready()) {
     ${display_id}->update();
   }
-  #endif
+  %:endif
 
   // Preprocessor macros lack scope so undefine the macro for another script
   // instance to have proper conditionals (i.e. prevent wrongly evaluating
   // macro for another triggering entity has own macro defined)
-  #undef TRIGGERED_BY_${triggered_by}
+  %:undef TRIGGERED_BY_${triggered_by}

--- a/script_refill_tank.yaml
+++ b/script_refill_tank.yaml
@@ -4,17 +4,17 @@
 if:
   condition:
     lambda: |-
-      #include <esphome/core/component.h>
+      %:include <esphome/core/component.h>
       return
         (${condition})
         // Ignore the fragment being triggered during 'sprinkler' component
         // setup when its switches are turned off initially (would be redundant)
         && (id(${sprinkler}).get_component_state() & COMPONENT_STATE_LOOP)
-        #ifdef HAS_CUSTOM_INPUTS
+        %:ifdef HAS_CUSTOM_INPUTS
         // Ignore attempt to refill the tank when it has already been reported
         // as empty (would be redundant)
         && !${water_tank_empty_id}->state
-        #endif  // HAS_CUSTOM_INPUTS
+        %:endif  // HAS_CUSTOM_INPUTS
         // Ignore attempt to refill the tank if controller is in standby
         && !id(${sprinkler}).standby();
   then:
@@ -24,16 +24,16 @@ if:
         level: INFO
     - switch.turn_on: ${relay}
     - lambda: |-
-        #ifdef HAS_DISPLAY
+        %:ifdef HAS_DISPLAY
         if (${display_id}->is_ready()) {
           ${display_id}->update();
         }
-        #endif
+        %:endif
     - delay: ${peripherals_power_refill_pulse_duration}
     - switch.turn_off: ${relay}
     - lambda: |-
-        #ifdef HAS_DISPLAY
+        %:ifdef HAS_DISPLAY
         if (${display_id}->is_ready()) {
           ${display_id}->update();
         }
-        #endif
+        %:endif

--- a/script_reset_controller.yaml
+++ b/script_reset_controller.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2025 Ilia Sotnikov
 ---
-!lambda |-
+|-
   // `true` parameter clears any queued values as well
   id(${sprinkler}).shutdown(true);
   id(${sprinkler}).reset_resume();


### PR DESCRIPTION
- ESPHome 2026.4.0 enforces the documented 0..127 range for `contrast` parameter of `display` component.
- ESPHome 2026.4.0 (see PR [#8955](https://github.com/esphome/esphome/pull/8955)) treats `#` as Jinja line statements, which conflicts with C/C++ preprocessor directives. Hence, C/C++ digraph `%:` is used for `#`.
- ESPHome 2026.4.0 (see PR [PR #12126](https://github.com/esphome/esphome/pull/12126) and PR [#14918](https://github.com/esphome/esphome/pull/14918)) changed substitutions in `!include`, so `!lambda` elements in included files are no longer evaludated for substitutions.