### PR TITLE
fix: Update dynamic-on-time component to 1.2.2

### DIFF
--- a/schedule.yaml
+++ b/schedule.yaml
@@ -204,7 +204,7 @@ number:
     mode: box
 
 external_components:
-  - source: github://hostcc/esphome-component-dynamic-on-time@1.2.1
+  - source: github://hostcc/esphome-component-dynamic-on-time@1.2.2
 
 script:
   - id: lawn_sprinklers_scheduled_cycle_start


### PR DESCRIPTION
Update `dynamic-on-time` component to [1.2.2](https://github.com/hostcc/esphome-component-dynamic-on-time/releases/tag/1.2.2) to fix compatibility issue with ESPHome 2026.4.0.