### PR TITLE
fix: Controller runtime minutes calculation

### DIFF
--- a/script_controller_run_time_remaining.yaml
+++ b/script_controller_run_time_remaining.yaml
@@ -7,7 +7,7 @@
 
   if (time_remaining > 0) {
     auto remaining_hours = time_remaining / 3600;
-    auto remaining_minutes = time_remaining / 60;
+    auto remaining_minutes = (time_remaining % 3600) / 60;
     auto remaining_seconds = time_remaining % 60;
 
     return


### PR DESCRIPTION
Previously, the `script_controller_run_time_remaining` script wasn't properly calculating minutes portion of the runtime remaining (not accounting for hours in the value). The calculation has been fixed to address that.