### PR TITLE
chore: Pin Dependabot Python version to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ESPHome"
 version = "0"
-# ESPHome doesn't allow Python 3.14, which Dependabot attempts to use - constrain
+# ESPHome now requires Python 3.12, while Dependabot might use a different one - constrain
 # the Python version correspondingly.
-requires-python = ">=3.11.0,<3.14"
+requires-python = ">=3.12.0,<3.14"


### PR DESCRIPTION
ESPHome 2026.7.0 uses Python 3.12 (esphome/esphome#17280), so pin the version for Depndabot accordingly